### PR TITLE
Add delimiers  to aliases

### DIFF
--- a/include/QxDao/QxSqlDatabase.h
+++ b/include/QxDao/QxSqlDatabase.h
@@ -119,6 +119,8 @@ public:
    bool getFormatSqlQueryBeforeLogging() const;
    QStringList getSqlDelimiterForTableName() const;
    QStringList getSqlDelimiterForColumnName() const;
+   QStringList getSqlDelimiterForTableNameAlias() const;
+   QStringList getSqlDelimiterForColumnNameAlias() const;
    int getTraceSqlOnlySlowQueriesDatabase() const;
    int getTraceSqlOnlySlowQueriesTotal() const;
    bool getDisplayTimerDetails() const;
@@ -149,6 +151,8 @@ public:
    void setFormatSqlQueryBeforeLogging(bool b, bool bJustForCurrentThread = false, QSqlDatabase * pJustForThisDatabase = NULL);
    void setSqlDelimiterForTableName(const QStringList & lst, bool bJustForCurrentThread = false, QSqlDatabase * pJustForThisDatabase = NULL);
    void setSqlDelimiterForColumnName(const QStringList & lst, bool bJustForCurrentThread = false, QSqlDatabase * pJustForThisDatabase = NULL);
+   void setSqlDelimiterForTableNameAlias(const QStringList & lst, bool bJustForCurrentThread = false, QSqlDatabase * pJustForThisDatabase = NULL);
+   void setSqlDelimiterForColumnNameAlias(const QStringList & lst, bool bJustForCurrentThread = false, QSqlDatabase * pJustForThisDatabase = NULL);  
    void setTraceSqlOnlySlowQueriesDatabase(int i, bool bJustForCurrentThread = false, QSqlDatabase * pJustForThisDatabase = NULL);
    void setTraceSqlOnlySlowQueriesTotal(int i, bool bJustForCurrentThread = false, QSqlDatabase * pJustForThisDatabase = NULL);
    void setDisplayTimerDetails(bool b, bool bJustForCurrentThread = false, QSqlDatabase * pJustForThisDatabase = NULL);

--- a/include/QxDataMember/IxDataMember.h
+++ b/include/QxDataMember/IxDataMember.h
@@ -197,6 +197,8 @@ public:
    static QString getSqlFromTable(const QString & sTable, const QString & sCustomAlias = QString());
    static QString getSqlTableName(const QString & sTable);
    static QString getSqlColumnName(const QString & sColumn);
+   static QString getSqlTableNameAlias(const QString & sTable);
+   static QString getSqlColumnNameAlias(const QString & sColumn);
 
    virtual bool isEqual(const void * pOwner1, const void * pOwner2) const = 0;
    virtual QVariant toVariant(const void * pOwner, const QString & sFormat, int iIndexName = -1, qx::cvt::context::ctx_type ctx = qx::cvt::context::e_no_context) const = 0;

--- a/src/QxDao/IxSqlRelation.cpp
+++ b/src/QxDao/IxSqlRelation.cpp
@@ -305,7 +305,8 @@ QString IxSqlRelation::tableAlias(QxSqlRelationParams & params) const
    if (! params.getCustomAlias().isEmpty()) { return params.getCustomAlias(); }
    QString sTableAlias = (m_pImpl->m_pDataMemberX ? (m_pImpl->m_pDataMemberX->getName() + "_" + QString::number(params.index())) : QString(""));
    sTableAlias.replace(".", "_");
-   return sTableAlias;
+   // wrap with alias with delimiter if needed
+   return IxDataMember::getSqlTableNameAlias(sTableAlias);
 }
 
 QString IxSqlRelation::tableAliasOwner(QxSqlRelationParams & params) const

--- a/src/QxDao/QxSqlDatabase.cpp
+++ b/src/QxDao/QxSqlDatabase.cpp
@@ -98,6 +98,8 @@ struct Q_DECL_HIDDEN QxSqlDatabase::QxSqlDatabaseImpl
    bool m_bFormatSqlQueryBeforeLogging;                     //!< Format SQL query (pretty-printing) before logging it (can be customized creating a qx::dao::detail::IxSqlGenerator sub-class)
    QStringList m_lstSqlDelimiterForTableName;               //!< Add delimiter characters for table name in SQL queries (to support specific database keywords) : for example, use ` for MySQL database
    QStringList m_lstSqlDelimiterForColumnName;              //!< Add delimiter characters for column name in SQL queries (to support specific database keywords) : for example, use ` for MySQL database
+   QStringList m_lstSqlDelimiterForTableNameAlias;          //!< Add delimiter characters for table name alias in SQL queries (to support specific database keywords) : for example, use ` for MySQL database
+   QStringList m_lstSqlDelimiterForColumnNameAlias;         //!< Add delimiter characters for column name alias in SQL queries (to support specific database keywords) : for example, use ` for MySQL database
    int m_iTraceSqlOnlySlowQueriesDatabase;                  //!< Trace only slow sql queries (database execution time only, in milliseconds)
    int m_iTraceSqlOnlySlowQueriesTotal;                     //!< Trace only slow sql queries (database execution time + C++ qx::dao execution time, in milliseconds)
    bool m_bDisplayTimerDetails;                             //!< Display in logs all timers details (exec(), next(), prepare(), open(), etc...)
@@ -364,6 +366,21 @@ QStringList QxSqlDatabase::getSqlDelimiterForColumnName() const
    return m_pImpl->m_lstSqlDelimiterForColumnName;
 }
 
+QStringList QxSqlDatabase::getSqlDelimiterForTableNameAlias() const
+{
+   if ((m_pImpl->m_lstSettingsByThread.count() <= 0) && (m_pImpl->m_lstSettingsByDatabase.count() <= 0)) { return m_pImpl->m_lstSqlDelimiterForTableNameAlias; }
+   QVariant setting = m_pImpl->getSetting("SqlDelimiterForTableNameAlias");
+   if (! setting.isNull()) { return setting.toStringList(); }
+   return m_pImpl->m_lstSqlDelimiterForTableNameAlias;
+}
+
+QStringList QxSqlDatabase::getSqlDelimiterForColumnNameAlias() const
+{
+   if ((m_pImpl->m_lstSettingsByThread.count() <= 0) && (m_pImpl->m_lstSettingsByDatabase.count() <= 0)) { return m_pImpl->m_lstSqlDelimiterForColumnNameAlias; }
+   QVariant setting = m_pImpl->getSetting("SqlDelimiterForColumnNameAlias");
+   if (! setting.isNull()) { return setting.toStringList(); }
+   return m_pImpl->m_lstSqlDelimiterForColumnNameAlias;
+}
 int QxSqlDatabase::getTraceSqlOnlySlowQueriesDatabase() const
 {
    if ((m_pImpl->m_lstSettingsByThread.count() <= 0) && (m_pImpl->m_lstSettingsByDatabase.count() <= 0)) { return m_pImpl->m_iTraceSqlOnlySlowQueriesDatabase; }
@@ -561,6 +578,18 @@ void QxSqlDatabase::setSqlDelimiterForColumnName(const QStringList & lst, bool b
 {
    bool bUpdateGlobal = m_pImpl->setSetting("SqlDelimiterForColumnName", lst, bJustForCurrentThread, pJustForThisDatabase);
    if (bUpdateGlobal) { m_pImpl->m_lstSqlDelimiterForColumnName = lst; }
+}
+
+void QxSqlDatabase::setSqlDelimiterForTableNameAlias(const QStringList & lst, bool bJustForCurrentThread /* = false */, QSqlDatabase * pJustForThisDatabase /* = NULL */)
+{
+   bool bUpdateGlobal = m_pImpl->setSetting("SqlDelimiterForTableNameAlias", lst, bJustForCurrentThread, pJustForThisDatabase);
+   if (bUpdateGlobal) { m_pImpl->m_lstSqlDelimiterForTableNameAlias = lst; }
+}
+
+void QxSqlDatabase::setSqlDelimiterForColumnNameAlias(const QStringList & lst, bool bJustForCurrentThread /* = false */, QSqlDatabase * pJustForThisDatabase /* = NULL */)
+{
+   bool bUpdateGlobal = m_pImpl->setSetting("SqlDelimiterForColumnNameAlias", lst, bJustForCurrentThread, pJustForThisDatabase);
+   if (bUpdateGlobal) { m_pImpl->m_lstSqlDelimiterForColumnNameAlias = lst; }
 }
 
 void QxSqlDatabase::setTraceSqlOnlySlowQueriesDatabase(int i, bool bJustForCurrentThread /* = false */, QSqlDatabase * pJustForThisDatabase /* = NULL */)

--- a/src/QxDataMember/IxDataMember.cpp
+++ b/src/QxDataMember/IxDataMember.cpp
@@ -694,6 +694,29 @@ QString IxDataMember::getSqlColumnName(const QString & sColumn)
    QString sResult = (sStart + sColumn + sEnd); sResult.replace(".", (sEnd + "." + sStart));
    return sResult;
 }
+QString IxDataMember::getSqlTableNameAlias(const QString & sTable)
+{
+   QStringList lstDelimiter = QxSqlDatabase::getSingleton()->getSqlDelimiterForTableNameAlias();
+   QString sStart = QString();
+   QString sEnd = QString();
+   if (lstDelimiter.count() > 0) { sStart = lstDelimiter.at(0); sEnd = lstDelimiter.at(0); }
+   if (lstDelimiter.count() > 1) { sEnd = lstDelimiter.at(1); }
+   if (sStart.isEmpty() || sEnd.isEmpty() || sTable.contains(sStart) || sTable.contains(sEnd)) { return sTable; }
+   QString sResult = (sStart + sTable + sEnd); sResult.replace(".", (sEnd + "." + sStart));
+   return sResult;
+}
+
+QString IxDataMember::getSqlColumnNameAlias(const QString & sColumn)
+{
+   QStringList lstDelimiter = QxSqlDatabase::getSingleton()->getSqlDelimiterForColumnNameAlias();
+   QString sStart = QString();
+   QString sEnd = QString();
+   if (lstDelimiter.count() > 0) { sStart = lstDelimiter.at(0); sEnd = lstDelimiter.at(0); }
+   if (lstDelimiter.count() > 1) { sEnd = lstDelimiter.at(1); }
+   if (sStart.isEmpty() || sEnd.isEmpty() || sColumn.contains(sStart) || sColumn.contains(sEnd)) { return sColumn; }
+   QString sResult = (sStart + sColumn + sEnd); sResult.replace(".", (sEnd + "." + sStart));
+   return sResult;
+}
 
 IxDataMemberSqlCallbackParams::IxDataMemberSqlCallbackParams(const IxDataMember * p, QString & sql) : pDataMember(p), sSQL(sql), bClauseWhere(false), bCheckFKPartOfPK(false), iIndexName(0), pDaoHelper(NULL), pSqlQueryBuilder(NULL) { qAssert(pDataMember); }
 

--- a/src/QxDataMember/IxDataMember.cpp
+++ b/src/QxDataMember/IxDataMember.cpp
@@ -578,7 +578,8 @@ QString IxDataMember::getSqlTablePointNameAsAlias(const QString & sTable, const 
    for (int i = 0; i < m_pImpl->m_lstNames.count(); i++)
    {
       if (bCheckFKPartOfPK && m_pImpl->m_bIsPrimaryKey && isThereRelationPartOfPrimaryKey(i, pRelation, iIndexNameFK)) { continue; }
-      sResult += sTableAlias + "." + getSqlColumnName(getName(i)) + sTableAliasSep + getSqlAlias((sCustomAlias.isEmpty() ? sTable : sCustomAlias), false, i, pSqlQueryBuilder) + sSuffixAlias + sSep;
+      // wrap alias with delimiters if needed
+      sResult += sTableAlias + "." + getSqlColumnName(getName(i)) + sTableAliasSep + getSqlColumnNameAlias(getSqlAlias((sCustomAlias.isEmpty() ? sTable : sCustomAlias), false, i, pSqlQueryBuilder) + sSuffixAlias) + sSep;
    }
 
    if (! sResult.isEmpty())
@@ -694,6 +695,7 @@ QString IxDataMember::getSqlColumnName(const QString & sColumn)
    QString sResult = (sStart + sColumn + sEnd); sResult.replace(".", (sEnd + "." + sStart));
    return sResult;
 }
+
 QString IxDataMember::getSqlTableNameAlias(const QString & sTable)
 {
    QStringList lstDelimiter = QxSqlDatabase::getSingleton()->getSqlDelimiterForTableNameAlias();


### PR DESCRIPTION
In some cases in some databases, we need to set delimiters for column and table names:
```
    qx::QxSqlDatabase::getSingleton()->setSqlDelimiterForTableName(QStringList() << "\"");
    qx::QxSqlDatabase::getSingleton()->setSqlDelimiterForColumnName(QStringList() << "\"");
```

Also, in some cases (for instant in oracle DB), we  need to  wrap with delimiters all table and column aliases. 
This small patch adds  this functionality:
```
    qx::QxSqlDatabase::getSingleton()->setSqlDelimiterForTableNameAlias(QStringList() << "\"");
    qx::QxSqlDatabase::getSingleton()->setSqlDelimiterForColumnNameAlias(QStringList() << "\"");
```