### PR TITLE
fix compile with QStringBuilder

### DIFF
--- a/src/QxHttpServer/QxHttpTransaction.cpp
+++ b/src/QxHttpServer/QxHttpTransaction.cpp
@@ -203,8 +203,16 @@ qx_bool QxHttpTransaction::readSocketServer(QTcpSocket & socket)
    if (! m_pImpl->waitForReadSocket(socket)) { setMessageReturn(qx_bool(500, "Internal server error : cannot read socket to parse HTTP request first line (" + socket.errorString() + ")")); return qx_bool(true); }
    QByteArray line = socket.readLine().trimmed();
    QStringList lst = QString::fromUtf8(line).split(" ");
-   if (lst.count() < 3) { setMessageReturn(qx_bool(400, "Bad request : invalid HTTP request first line : " + line)); return qx_bool(true); }
-   if (! lst.at(2).contains("HTTP")) { setMessageReturn(qx_bool(400, "Bad request : invalid HTTP request first line, third parameter must contain 'HTTP' : " + line)); return qx_bool(true); }
+   if (lst.count() < 3) {
+      QString errMsg("Bad request : invalid HTTP request first line : " + line);
+      setMessageReturn(qx_bool(400, errMsg));
+      return qx_bool(true);
+   }
+   if (! lst.at(2).contains("HTTP")) {
+      QString errMsg("Bad request : invalid HTTP request first line, third parameter must contain 'HTTP' : " + line);
+      setMessageReturn(qx_bool(400, errMsg));
+      return qx_bool(true);
+   }
    m_pImpl->m_request.command() = lst.at(0).toUpper();
    m_pImpl->m_request.url() = QUrl(lst.at(1));
    m_pImpl->m_request.version() = lst.at(2);
@@ -215,7 +223,12 @@ qx_bool QxHttpTransaction::readSocketServer(QTcpSocket & socket)
    {
       if (! m_pImpl->waitForReadSocket(socket)) { setMessageReturn(qx_bool(500, "Internal server error : cannot read socket to parse HTTP headers (" + socket.errorString() + ")")); return qx_bool(true); }
       line = socket.readLine().trimmed(); if (line.isEmpty()) { break; }
-      int pos = line.indexOf(':'); if (pos <= 0) { setMessageReturn(qx_bool(400, "Bad request : invalid HTTP header : " + line)); return qx_bool(true); }
+      int pos = line.indexOf(':');
+      if (pos <= 0) {
+         QString errMsg("Bad request : invalid HTTP header : " + line);
+         setMessageReturn(qx_bool(400, errMsg));
+         return qx_bool(true);
+      }
       QByteArray key = line.left(pos).trimmed();
       QByteArray value = line.mid(pos + 1).trimmed();
 #if (QT_VERSION >= 0x060000)


### PR DESCRIPTION
`_QX_USE_QSTRINGBUILDER` + `_QX_ENABLE_QT_NETWORK` caused compile error in `QxHttpTransaction.cpp`

This is the same bug that caused QxOrm/QxOrm#50, just in a different spot. Same fix, though.