### PR TITLE
TEST program -qxBlog- cannot find QxOrm lib in compiling with cmake

### DIFF
--- a/QxOrm.cmake
+++ b/QxOrm.cmake
@@ -56,6 +56,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(QXORM_DIR ${CMAKE_CURRENT_LIST_DIR})
 set(QXORM_INCLUDE_DIR ${QXORM_DIR}/include)
 include_directories(${QXORM_INCLUDE_DIR})
+#add h-inomata & akiba-taro
+set(QXORM_LIB_DIR ${QXORM_DIR}/lib)
+link_directories(${QXORM_LIB_DIR})
 
 ###########################################
 # Boost Header-Only Dependency (optional) #


### PR DESCRIPTION
I am a new of Qt, QxOrm and cmake.

The sample programs -qxBlog- in the test dir work fine in building with .pro file.
That's greate.

But they cannot find QxOrm lib in compiling with cmake.

Therefore I add some code into QxOrm.cmake file in order to specify QxOrm lib location .

In this case sample programs are built successfully.

Is it right way?

